### PR TITLE
Sliders not showing up in Firefox

### DIFF
--- a/html/main.css
+++ b/html/main.css
@@ -27,6 +27,7 @@ input:invalid {
 
 input[type="range"] {
     width: 150px;
+    border: 1px solid transparent;
 }
 
 label {


### PR DESCRIPTION
Hi, I didn't even code with Flare yet, but I've noticed that in all current samples available online the sliders are invisible:

Tutorial:

![screenshot from 2016-06-15 14-43-14](https://cloud.githubusercontent.com/assets/1269815/16090934/deb2c004-3307-11e6-8c13-668e112d0479.png)

Tests (mouse pointer was over the invisible slider, hence the selection box):

![screenshot from 2016-06-15 14-43-32](https://cloud.githubusercontent.com/assets/1269815/16090952/e7d2047e-3307-11e6-918a-165520df24d9.png)

Try Flare (mouse pointer was over the invisible slider, hence the selection box):

![screenshot from 2016-06-15 14-44-22](https://cloud.githubusercontent.com/assets/1269815/16090962/f1a3ee40-3307-11e6-9ebb-f1d14c382601.png)

Except for purescript-isometric which shows sliders correctly:

![screenshot from 2016-06-15 14-42-54](https://cloud.githubusercontent.com/assets/1269815/16091021/29816900-3308-11e6-96fd-6cb36a319f45.png)

I'm on ArchLinux with Gnome 3.
