### PR TITLE
Run an inner Flare with access to current value

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "purescript-drawing": "^3.0.0",
     "purescript-smolder": "^10.0.0",
     "purescript-nonempty": "^4.0.0",
-    "purescript-datetime": "^3.0.0"
+    "purescript-datetime": "^3.0.0",
+    "purescript-tuples": "^4.1.0"
   }
 }

--- a/html/index.html
+++ b/html/index.html
@@ -161,26 +161,26 @@ data Domain = HSL | RGB
 showDomain HSL = "HSL"
 showDomain RGB = "RGB"
 
-toHTML c = H.div `H.with` (A.style $ "background-color:" &lt;&gt; hex) $ H.text hex
-  where hex = colorString c
+toHTML c = H.div `H.with` (A.style $ "background-color:" <> hex) $ H.text hex
+  where hex = cssStringHSLA c
 
 ns l = numberSlider l 0.0
+
+is l = intSlider l 0 255
 
 uiColor HSL = hsl <$> ns "Hue"        360.0  1.0 180.0
                   <*> ns "Saturation"   1.0 0.01   0.5
                   <*> ns "Lightness"    1.0 0.01   0.5
-uiColor RGB = rgb <$> ns "Red"        255.0  1.0 200.0
-                  <*> ns "Green"      255.0  1.0   0.0
-                  <*> ns "Blue"       255.0  1.0 100.0
+uiColor RGB = rgb <$> is "Red"   200
+                  <*> is "Green"   0
+                  <*> is "Blue"  100
 
 inner = runFlareHTML "controls14b" "output14" <<< map toHTML <<< uiColor
 
-ui = select "Color domain" (HSL :| [RGB]) showDomain
-
-main = runFlareWith "controls14a" inner ui
+ui = traverse_ toHTML <$>
+     select "Color domain" (HSL :| [RGB]) showDomain `innerFlare` uiColor
 </pre>
-        <div id="controls14a"></div>
-        <div id="controls14b"></div>
+        <div id="controls14"></div>
         <div id="output14"></div>
 
         <h3>Example 15: Multiple buttons</h3>

--- a/html/index.html
+++ b/html/index.html
@@ -175,7 +175,7 @@ uiColor RGB = rgb <$> is "Red"   200
                   <*> is "Green"   0
                   <*> is "Blue"  100
 
-ui = traverse_ toHTML <$>
+ui = toHTML <$>
      select "Color domain" (HSL :| [RGB]) showDomain `innerFlare` uiColor
 </pre>
         <div id="controls14"></div>

--- a/html/index.html
+++ b/html/index.html
@@ -175,8 +175,6 @@ uiColor RGB = rgb <$> is "Red"   200
                   <*> is "Green"   0
                   <*> is "Blue"  100
 
-inner = runFlareHTML "controls14b" "output14" <<< map toHTML <<< uiColor
-
 ui = traverse_ toHTML <$>
      select "Color domain" (HSL :| [RGB]) showDomain `innerFlare` uiColor
 </pre>

--- a/src/Flare.js
+++ b/src/Flare.js
@@ -23,6 +23,18 @@ exports.removeChildren = function(target) {
   };
 };
 
+exports.createInnerElementP = function(tuple) {
+  return function () {
+    var uid = getUniqueID();
+    var el = document.createElement('div');
+    el.id = uid;
+    // append element to body so it can be found by getElementById.
+    // It will be moved to the right place later when rendering
+    document.body.append(el);
+    return tuple(uid)(el);
+  };
+};
+
 exports.appendComponent = function(target) {
   return function(el) {
     return function() {

--- a/src/Flare.js
+++ b/src/Flare.js
@@ -35,6 +35,12 @@ exports.createInnerElementP = function(tuple) {
   };
 };
 
+exports.get = function (sig) {
+  return function () {
+    return sig.get();
+  };
+};
+
 exports.appendComponent = function(target) {
   return function(el) {
     return function() {

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,43 +2,34 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
 import Control.Apply (lift2)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Timer (TIMER)
+import DOM (DOM)
 import Data.Array (cons, (..), length, zipWith)
-import Data.NonEmpty ((:|))
-import Data.Maybe (maybe, fromMaybe)
-import Data.Monoid (mempty)
+import Data.Date (canonicalDate, diff)
 import Data.Enum (toEnum)
 import Data.Foldable (foldMap, sum, traverse_)
 import Data.Int (toNumber, round)
 import Data.List (List(..), (:))
-import Data.Traversable (traverse)
-import Data.Date (canonicalDate, diff)
-import Data.Time.Duration (Days(..))
-import Data.String (take)
+import Data.Maybe (maybe, fromMaybe)
+import Data.Monoid (mempty)
 import Data.Newtype (un)
-import Math (pow, sin, cos, pi, abs)
-
-import DOM (DOM)
-import Signal.Channel (CHANNEL)
+import Data.NonEmpty ((:|))
+import Data.String (take)
+import Data.Time.Duration (Days(..))
+import Data.Traversable (traverse)
+import Flare (UI, runFlareShow, runFlare, button, liftSF, buttons, foldp, select, intSlider, numberSlider, string, innerFlare, intSlider_, boolean_, lift, color, number_, int_, string_, number, (<**>), date, resizableList)
+import Flare.Drawing (Color, Drawing, runFlareDrawing, rgb, hsl, cssStringHSLA, path, lineWidth, black, outlineColor, outlined, fillColor, filled, circle)
+import Flare.Smolder (runFlareHTML)
 import Graphics.Canvas (CANVAS)
-import Control.Monad.Eff.Timer (TIMER)
-
+import Math (pow, sin, cos, pi, abs)
+import Signal.Channel (CHANNEL)
 import Signal.DOM (animationFrame)
 import Signal.Time (since)
-
 import Text.Smolder.HTML (div, li, ul, table, td, tr) as H
-import Text.Smolder.Markup (Markup, with, text) as H
 import Text.Smolder.HTML.Attributes as A
-
-import Flare (UI, runFlareShow, runFlareWith, runFlare, button, liftSF, buttons,
-              foldp, select, intSlider, numberSlider, string, intSlider_,
-              boolean_, lift, color, number_, int_, string_, number, (<**>),
-              date, resizableList)
-import Flare.Drawing (Color, Drawing, runFlareDrawing, rgb, hsl, cssStringHSLA,
-                      path, lineWidth, black, outlineColor, outlined, fillColor,
-                      filled, circle)
-import Flare.Smolder (runFlareHTML)
+import Text.Smolder.Markup (Markup, with, text) as H
 
 -- Example 1
 
@@ -192,8 +183,9 @@ uiColor RGB = rgb <$> is "Red"   200
 inner :: forall e. Domain -> Eff (dom :: DOM, channel :: CHANNEL | e) Unit
 inner = runFlareHTML "controls14b" "output14" <<< map toHTML <<< uiColor
 
-ui14 :: forall e. UI e Domain
-ui14 = select "Color domain" (HSL :| [RGB]) showDomain
+ui14 :: forall e m. UI e (H.Markup m)
+ui14 = traverse_ toHTML <$>
+       select "Color domain" (HSL :| [RGB]) showDomain `innerFlare` uiColor
 
 -- Example 15
 
@@ -260,7 +252,7 @@ main = do
   runFlareHTML    "controls12"  "output12" ui12
   runFlareShow    "controls11"  "output11" ui11
   runFlareHTML    "controls13"  "output13" ui13
-  runFlareWith    "controls14a"     inner  ui14
+  runFlareHTML    "controls14"  "output14" ui14
   runFlareShow    "controls15"  "output15" ui15
   runFlareHTML    "controls16"  "output16" ui16
   runFlare        "controls17"  "output17" ui17

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -180,9 +180,6 @@ uiColor RGB = rgb <$> is "Red"   200
                   <*> is "Green"   0
                   <*> is "Blue"  100
 
-inner :: forall e. Domain -> Eff (dom :: DOM, channel :: CHANNEL | e) Unit
-inner = runFlareHTML "controls14b" "output14" <<< map toHTML <<< uiColor
-
 ui14 :: forall e m. UI e (H.Markup m)
 ui14 = traverse_ toHTML <$>
        select "Color domain" (HSL :| [RGB]) showDomain `innerFlare` uiColor

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -181,7 +181,7 @@ uiColor RGB = rgb <$> is "Red"   200
                   <*> is "Blue"  100
 
 ui14 :: forall e m. UI e (H.Markup m)
-ui14 = traverse_ toHTML <$>
+ui14 = toHTML <$>
        select "Color domain" (HSL :| [RGB]) showDomain `innerFlare` uiColor
 
 -- Example 15


### PR DESCRIPTION
Example 14 in the docs shows how to do a component dependent on the previous values in the UI, but it requires separate markup and is hard to replace an existing `UI` with - the types have to be changed all around.

This PR adds a function to set up an inner UI with access to the current value - see updated example 14 for motivation and usage.

There are a few rough edges that I hope to get some advice on:

* bodil/purescript-signal#60 would simplify the types - right now there's an ugly `Maybe` to work around.
* An empty container for the inner UI is appended to the body (but immediately reattached where needed) - to change this either `ElementId` or element cleanup logic needs changing.

The signature gets `UI` close to being a `Monad`, but I decided not to implement the instance because the performance and user experience of recreating the inner UI each time would be awful if it's used as a base for `apply`.