### PR TITLE
Updated broken dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "purescript-foldable-traversable": "^4.0.0",
     "purescript-nonempty": "^5.0.0",
     "purescript-signal": "^10.1.0",
-    "purescript-smolder": "^11.0.0",
+    "purescript-smolder": "^12.0.0",
     "purescript-tuples": "^5.0.0",
     "purescript-web-dom": "^1.0.0"
   }


### PR DESCRIPTION
Could not build project with the current version, so added a newer one that works.

The issue is that the old version uses this character '\0', which is not supported in the newer version of the compiler for some reason.