### PR TITLE
Use appendChild() instead of append().

### DIFF
--- a/src/Flare.js
+++ b/src/Flare.js
@@ -30,7 +30,7 @@ exports.createInnerElementP = function(tuple) {
     el.id = uid;
     // append element to body so it can be found by getElementById.
     // It will be moved to the right place later when rendering
-    document.body.append(el);
+    document.body.appendChild(el);
     return tuple(uid)(el);
   };
 };


### PR DESCRIPTION
After reading [MDN's comparison of `ParentNode.append()` and `Node.appendChild()`](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append), it seems clear that `Node.appendChild()` is sufficient for this use case, while `ParentNode.append()` is unsupported in Internet Explorer.